### PR TITLE
Score order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /test_search_index/
 /.eggs/
 /htmlcov/
+venv/

--- a/wagtail_whoosh/backend.py
+++ b/wagtail_whoosh/backend.py
@@ -344,7 +344,7 @@ class WhooshSearchResults(BaseSearchResults):
 
     def _do_count(self):
         return self.query_compiler.search(
-            self.backend, None, None).count()
+            self.backend, None, None, None).count()
 
 
 class WhooshSearchRebuilder:

--- a/wagtail_whoosh/backend.py
+++ b/wagtail_whoosh/backend.py
@@ -141,7 +141,7 @@ class Index:
                 writer.delete_by_query(q=self.backend.parser.parse('%s:"%s"' % (ID, query_string)))
                 writer.commit()
             except Exception as e:
-                raise
+                raise e
 
     def add_items(self, model, objs):
         for obj in objs:
@@ -163,7 +163,7 @@ class Index:
             try:
                 writer.update_document(**doc)
             except Exception as e:
-                raise
+                raise e
 
         if len(objs) > 0:
             writer.commit()
@@ -177,7 +177,7 @@ class Index:
             writer.delete_by_query(q=self.backend.parser.parse('%s:"%s"' % (ID, whoosh_id)))
             writer.commit()
         except Exception as e:
-            raise
+            raise e
 
     def __str__(self):
         return self.name

--- a/wagtail_whoosh/backend.py
+++ b/wagtail_whoosh/backend.py
@@ -3,11 +3,9 @@ import re
 import shutil
 from warnings import warn
 
-from django.db import (DEFAULT_DB_ALIAS, NotSupportedError, connections,
-                       models, transaction)
-from django.db.models import F, Manager, Q, TextField, Value
+from django.db import DEFAULT_DB_ALIAS, models
+from django.db.models import Manager, Q
 from django.utils import six
-from django.utils.datetime_safe import datetime
 from django.utils.encoding import force_text
 
 from wagtail.search import index
@@ -17,18 +15,15 @@ from wagtail.search.backends.base import (BaseSearchBackend,
 from wagtail.search.index import RelatedFields, SearchField
 from wagtail.search.query import (And, MatchAll, Not, Or, SearchQueryShortcut,
                                   Term)
-from wagtail.search.utils import ADD, AND, OR
+from wagtail.search.utils import AND, OR
 
 from whoosh.fields import ID as WHOOSH_ID
-from whoosh.fields import (IDLIST, KEYWORD, NGRAM, NGRAMWORDS, NUMERIC, TEXT,
-                           Schema)
-from whoosh.filedb.filestore import FileStorage, RamStorage
+from whoosh.fields import TEXT, Schema
+from whoosh.filedb.filestore import FileStorage
 from whoosh.qparser import FuzzyTermPlugin, QueryParser
-from whoosh.writing import AsyncWriter, IndexWriter
+from whoosh.writing import AsyncWriter
 
-from .utils import (WEIGHTS_VALUES, get_ancestors_content_types_pks,
-                    get_content_type_pk, get_descendant_models, get_weight,
-                    unidecode)
+from .utils import get_descendant_models, get_weight, unidecode
 
 ID = "id"
 DJANGO_CT = "django_ct"


### PR DESCRIPTION
Order results by score rather than pk

Also added the option to annotate results with their score, similar to elastic search.

You can now do the following to mix multiple search results:
```
results = Page1.objects.search(query).annotate_score("_score").results()
result += Page2.objects.search(query).annotate_score("_score").results()
return sorted(results, key=lambda r: r._score)
```