### PR TITLE
Performance options

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,27 @@ WAGTAILSEARCH_BACKENDS = {
 }
 ```
 
+### Optimisations
+
+By default the Whoosh indexer uses 1 processor and 128mb of memory max. This can be changed using the `PROCS` and `Memory` options.
+
+e.g.
+
+```Python
+
+WAGTAILSEARCH_BACKENDS = {
+    'default': {
+        'BACKEND': 'wagtail_whoosh.backend',
+        'PATH': str(ROOT_DIR('search_index')),
+        'PROCS': 4,
+        'MEMORY': 2048,
+    },
+}
+```
+
+note: memory is calculated (per processor)[https://whoosh.readthedocs.io/en/latest/batch.html#the-procs-parameter], so the above configuration can use up to 8Gb of memory.
+
+
 ## NOT-Supported features
 
 1. `facet` is not supported.
-

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Set `./manage.py update_index` as cron job
 
 If you want to search `hello world`, you might need to use `hello` in previous versions. Now you can use `hel` and the backend would return the result.
 
-```
+```python
 # you need to define the search field in this way
 index.SearchField('title', partial_match=True)
 
@@ -43,7 +43,7 @@ index.AutocompleteField('title')
 
 ### Specifying the fields to search
 
-```
+```python
 # Search just the title field
 >>> EventPage.objects.search("Event", fields=["title"])
 [<EventPage: Event 1>, <EventPage: Event 2>]
@@ -51,7 +51,7 @@ index.AutocompleteField('title')
 
 ### Score support
 
-```
+```python
 results = Page1.objects.search(query).annotate_score("_score").results()
 result += Page2.objects.search(query).annotate_score("_score").results()
 return sorted(results, key=lambda r: r._score)
@@ -86,13 +86,13 @@ WAGTAILSEARCH_BACKENDS = {
 }
 ```
 
-### Optimisations
+## Optimisations
 
-By default the Whoosh indexer uses 1 processor and 128mb of memory max. This can be changed using the `PROCS` and `Memory` options.
+### Indexing speed
 
-e.g.
+By default the Whoosh indexer uses 1 processor and 128mb of memory max. This can be changed using the `PROCS` and `MEMORY` options:
 
-```Python
+```python
 
 WAGTAILSEARCH_BACKENDS = {
     'default': {
@@ -104,7 +104,22 @@ WAGTAILSEARCH_BACKENDS = {
 }
 ```
 
-note: memory is calculated (per processor)[https://whoosh.readthedocs.io/en/latest/batch.html#the-procs-parameter], so the above configuration can use up to 8Gb of memory.
+note: memory is calculated [per processor](https://whoosh.readthedocs.io/en/latest/batch.html#the-procs-parameter), so the above configuration can use up to 8Gb of memory.
+
+### NGRAM lengths
+
+The default minimum length for NGRAM words is 2, and the maximum is 8. For indexes with lots of partial match fields, or languages other than English, this could be too large. It can be customised using the `NGRAM_LENGTH` option:
+
+```python
+WAGTAILSEARCH_BACKENDS = {
+    'default': {
+        'BACKEND': 'wagtail_whoosh.backend',
+        'PATH': str(ROOT_DIR('search_index')),
+        'NGRAM_LENGTH': (2, 4),
+    },
+}
+```
+[further reading](https://whoosh.readthedocs.io/en/latest/ngrams.html#indexing-and-searching-n-grams)
 
 
 ## NOT-Supported features

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ WAGTAILSEARCH_BACKENDS = {
 
 ### Indexing speed
 
-By default the Whoosh indexer uses 1 processor and 128mb of memory max. This can be changed using the `PROCS` and `MEMORY` options:
+By default the Whoosh indexer uses 1 processor and 128MB of memory max. This can be changed using the `PROCS` and `MEMORY` options:
 
 ```python
 
@@ -104,7 +104,7 @@ WAGTAILSEARCH_BACKENDS = {
 }
 ```
 
-note: memory is calculated [per processor](https://whoosh.readthedocs.io/en/latest/batch.html#the-procs-parameter), so the above configuration can use up to 8Gb of memory.
+note: memory is calculated [per processor](https://whoosh.readthedocs.io/en/latest/batch.html#the-procs-parameter), so the above configuration can use up to 8GB of memory.
 
 ### NGRAM lengths
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -5,11 +5,13 @@ import copy
 
 from django.conf import settings
 from django.test import TestCase, override_settings
-from django.utils import timezone
+
+from wagtail.search.index import AutocompleteField
 from wagtail.search.tests.test_backends import BackendTests
 from wagtail.tests.search import models
 
 from whoosh.analysis import LanguageAnalyzer
+from whoosh.analysis.ngrams import NgramFilter
 
 sv_search_setttings_language = copy.deepcopy(settings.WAGTAILSEARCH_BACKENDS)
 sv_search_setttings_language['default']['LANGUAGE'] = 'sv'
@@ -17,6 +19,13 @@ sv_search_setttings_language['default']['LANGUAGE'] = 'sv'
 analyzer_swedish = LanguageAnalyzer('sv')
 sv_search_setttings_analyzer = copy.deepcopy(settings.WAGTAILSEARCH_BACKENDS)
 sv_search_setttings_analyzer['default']['ANALYZER'] = analyzer_swedish
+
+indexing_resources = copy.deepcopy(settings.WAGTAILSEARCH_BACKENDS)
+indexing_resources['default']['MEMORY'] = 2048
+indexing_resources['default']['PROCS'] = 2
+
+ngram_length = copy.deepcopy(settings.WAGTAILSEARCH_BACKENDS)
+ngram_length['default']['NGRAM_LENGTH'] = (3, 9)
 
 
 class TestWhooshSearchBackend(BackendTests, TestCase):
@@ -61,3 +70,26 @@ class TestWhooshSearchBackend(BackendTests, TestCase):
         self.assertUnsortedListEqual([r.name for r in results], [
             self.swedish_author.name,
         ])
+
+    @override_settings(WAGTAILSEARCH_BACKENDS=indexing_resources)
+    def test_resource_settings(self):
+        # Test that the writer kwargs are changed via settings
+        self.setUp()
+        index = self.backend.get_index_for_model(models.Author)
+        writer_args = index._writer_args()
+
+        self.assertEquals({
+            'limitmb': 2048,
+            'procs': 2,
+        }, writer_args)
+
+    @override_settings(WAGTAILSEARCH_BACKENDS=ngram_length)
+    def test_ngram_length_settings(self):
+        self.setUp()
+        test_field = AutocompleteField('Test')
+        whoosh_field = self.backend._to_whoosh_field(test_field)[1]
+        # Find the NgramFilter from the Composite Analyzer
+        filter = next(analyzer for analyzer in whoosh_field.analyzer if isinstance(analyzer, NgramFilter))
+
+        self.assertEquals(3, filter.min)
+        self.assertEquals(9, filter.max)

--- a/wagtail_whoosh/backend.py
+++ b/wagtail_whoosh/backend.py
@@ -375,6 +375,7 @@ class WhooshSearchResults(BaseSearchResults):
 class WhooshSearchRebuilder:
     def __init__(self, model_index):
         self.model_index = model_index
+        self.model_index.rebuilding = True
 
     def start(self):
         """

--- a/wagtail_whoosh/backend.py
+++ b/wagtail_whoosh/backend.py
@@ -412,6 +412,7 @@ class WhooshSearchBackend(BaseSearchBackend):
         self.path = params.get("PATH")
         self.processors = params.get("PROCS", 1)
         self.memory = params.get("MEMORY", 128)
+        self.ngram_length = params.get("NGRAM_LENGTH", (2, 8))
         # Flag for rebuilder, we only want the index folder emptied by the
         # first WhooshSearchRebuilder ran
         self.recreate_path_already = False
@@ -508,8 +509,8 @@ class WhooshSearchBackend(BaseSearchBackend):
         # If the field is AutocompleteField or has partial_match field, treat it as auto complete field
         if isinstance(field, AutocompleteField) or \
                 (hasattr(field, 'partial_match') and field.partial_match):
-            # TODO: make NGRAMWORDS configurable
-            whoosh_field = NGRAMWORDS(stored=False, minsize=2, maxsize=8, queryor=True)
+            whoosh_field = NGRAMWORDS(
+                stored=False, minsize=self.ngram_length[0], maxsize=self.ngram_length[1], queryor=True)
         else:
             # TODO other types of fields https://whoosh.readthedocs.io/en/latest/api/fields.htm
             whoosh_field = TEXT(

--- a/wagtail_whoosh/backend.py
+++ b/wagtail_whoosh/backend.py
@@ -21,8 +21,7 @@ from whoosh.analysis import analyzers
 from whoosh.fields import ID as WHOOSH_ID
 from whoosh.fields import NGRAMWORDS, TEXT, Schema
 from whoosh.filedb.filestore import FileStorage
-from whoosh.index import EmptyIndexError
-from whoosh.qparser import FuzzyTermPlugin, MultifieldParser, QueryParser
+from whoosh.qparser import MultifieldParser
 from whoosh.writing import AsyncWriter
 
 from .utils import get_boost, get_descendant_models, unidecode


### PR DESCRIPTION
Whoosh's defaults are quite low (1 processor  + 128mb). On large indexes this is verrrry slow. 
So I've added some options per the docs: https://whoosh.readthedocs.io/en/latest/batch.html

I also made the ngram min/max length configurable